### PR TITLE
remove returning hashed password

### DIFF
--- a/flask_app/app.py
+++ b/flask_app/app.py
@@ -135,6 +135,7 @@ def get_all_users(current_user):
     results = []
 
     for user in collection.find():
+        del user['password']
         results.append(user)
 
     return jsonify({'users': results})


### PR DESCRIPTION
Development endpoint to list users registered to the local mongodb instance would return a list of `user` items. This contained a hashed password. 
As this repo is now public, make sense to keep secure and not return this. 

To be clear all accounts and passwords link so a locally hosted mongodb instance, not included in this code. I am just following some good hygiene practises. 